### PR TITLE
Fix Macie findings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1642,7 +1642,7 @@ JSON
 }
 
 resource "aws_cloudwatch_event_target" "macie_finding" {
-  count = (var.macie_alert && var.enabled) ? 1 : 0
+  count = (var.macie_finding && var.enabled) ? 1 : 0
 
   rule      = join("", aws_cloudwatch_event_rule.macie_finding.*.name)
   target_id = "marbot"

--- a/variables.tf
+++ b/variables.tf
@@ -189,9 +189,9 @@ variable "ecs_spot_interruption" {
   default     = true
 }
 
-variable "macie_alert" {
+variable "macie_finding" {
   type        = bool
-  description = "Receive an alert, if Macie fires an alert."
+  description = "Receive an alert, if Macie generates a new finding."
   default     = true
 }
 


### PR DESCRIPTION
It seems like "Macie Alert" are no longer a thing. Therefore, I propose to filter for "Macie Findings".

https://docs.aws.amazon.com/macie/latest/user/findings-publish-event-schemas.html
https://docs.aws.amazon.com/macie/latest/user/findings-severity.html