### PR TITLE
fix: Improve ECR Image Scan rule to remove the need for backend filtering

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2041,18 +2041,21 @@ resource "aws_cloudwatch_event_rule" "ecr_image_scan_finding" {
   tags          = var.tags
   event_pattern = <<JSON
 {
-  "source": [ 
+  "source": [
     "aws.ecr"
   ],
   "detail-type": [
     "ECR Image Scan"
   ],
   "detail": {
+    "scan-status": ["COMPLETE"],
     "finding-severity-counts": {
-      "CRITICAL": [{"exists": false}, {"numeric": [">", 0]}],
-      "HIGH": [{"exists": false}, {"numeric": [">", 0]}],
-      "MEDIUM": [{"exists": false}, {"numeric": [">", 0]}],
-      "UNDEFINED": [{"exists": false}, {"numeric": [">", 0]}]
+      "$or": [
+        {"CRITICAL": [{"numeric": [">", 0]}]},
+        {"HIGH": [{"numeric": [">", 0]}]},
+        {"MEDIUM": [{"numeric": [">", 0]}]},
+        {"UNDEFINED": [{"numeric": [">", 0]}]}
+      ]
     }
   }
 }


### PR DESCRIPTION
see https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-complex-example-or